### PR TITLE
Fixed the issue of removing pods whose status are "assigned" or bound…

### DIFF
--- a/globalscheduler/cmd/scheduler_process/mock_scheduler/scheduler.go
+++ b/globalscheduler/cmd/scheduler_process/mock_scheduler/scheduler.go
@@ -106,9 +106,9 @@ func (s *Scheduler) initInformers(quit chan struct{}) {
 		},
 	})
 
-	podSelector := fields.ParseSelectorOrDie("status.phase=assigned,status.assignedScheduler.name!=''")
+	podSelector := fields.ParseSelectorOrDie("status.phase=" + string(v1.PodAssigned) + ",status.assignedScheduler.name!=''")
 	if len(s.name) > 0 {
-		podSelector = fields.ParseSelectorOrDie("status.phase=assigned,status.assignedScheduler.name=" + s.name)
+		podSelector = fields.ParseSelectorOrDie("status.phase=" + string(v1.PodAssigned) + ",status.assignedScheduler.name=" + s.name)
 	}
 
 	lw := cache.NewListWatchFromClient(s.clientset.CoreV1(), string(v1.ResourcePods), metav1.NamespaceAll, podSelector)
@@ -139,7 +139,7 @@ func (s *Scheduler) initInformers(quit chan struct{}) {
 				return
 			}
 			fmt.Printf("A  pod %s has been updated\n", newPod.Name)
-			if oldPod.Status.Phase != "assigned" && newPod.Status.Phase == "assigned" {
+			if oldPod.Status.Phase != v1.PodAssigned && newPod.Status.Phase == v1.PodAssigned {
 				s.podQueue <- newPod
 			}
 		},

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2413,10 +2413,11 @@ const (
 	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
 	// to an error in communicating with the host of the pod.
 	PodUnknown PodPhase = "Unknown"
-	// SchedulerAssigned represents status of the assigned scheduler for this pod.
-	SchedulerAssigned PodPhase = "assigned"
-	// ClusterBinded represents status of the binded cluster for this pod.
-	ClusterBinded PodPhase = "binded"
+
+	// PodAssigned means that the pod has a scheduler assigned to.
+	PodAssigned PodPhase = "Assigned"
+	// PodBound means that the pod has a cluster bound to.
+	PodBound PodPhase = "Bound"
 )
 
 type PodConditionType string

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -1,5 +1,6 @@
 /*
 Copyright 2015 The Kubernetes Authors.
+Copyright 2020 Authors of Arktos - file modified.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -99,7 +100,7 @@ func (gcc *PodGCController) gc() {
 }
 
 func isPodTerminated(pod *v1.Pod) bool {
-	if phase := pod.Status.Phase; phase != v1.PodPending && phase != v1.PodRunning && phase != v1.PodUnknown {
+	if phase := pod.Status.Phase; phase != v1.PodPending && phase != v1.PodRunning && phase != v1.PodUnknown && phase != v1.PodAssigned && phase != v1.PodBound {
 		return true
 	}
 	return false

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -192,10 +192,10 @@ func (r *BindingREST) setPodHostAndAnnotations(ctx context.Context, podID, oldMa
 		switch targetKind {
 		case "Scheduler":
 			pod.Status.AssignedScheduler.Name = targetName
-			pod.Status.Phase = api.SchedulerAssigned
+			pod.Status.Phase = api.PodAssigned
 		case "Cluster":
 			pod.Spec.ClusterName = targetName
-			pod.Status.Phase = api.ClusterBinded
+			pod.Status.Phase = api.PodBound
 		default:
 			if pod.Spec.VirtualMachine == nil && pod.Spec.NodeName != oldMachine {
 				return nil, fmt.Errorf("pod %v is already assigned to node %q", pod.Name, pod.Spec.NodeName)

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2657,6 +2657,11 @@ const (
 
 	// PodNoSchedule means pod should not be scheduled to any node
 	PodNoSchedule PodPhase = "NoSchedule"
+
+	// PodAssigned means that the pod has a scheduler assigned to.
+	PodAssigned PodPhase = "Assigned"
+	// PodBound means that the pod has a cluster bound to.
+	PodBound PodPhase = "Bound"
 )
 
 // PodConditionType is a valid value for PodCondition.Type


### PR DESCRIPTION
…" (#145)

 Fixed the issue of removing pods whose status are "assigned" or bound"

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
